### PR TITLE
Dry run does everything except release

### DIFF
--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -130,18 +130,11 @@ func main() {
 	}
 	logger.Println("new version: " + newVer.String())
 
-	if *dry {
-		exitIfError(errors.New("DRY RUN: no release was created"))
-	}
-
 	logger.Println("generating changelog...")
 	changelog := semrel.GetChangelog(commits, release, newVer)
 	if *changelogFile != "" {
 		exitIfError(ioutil.WriteFile(*changelogFile, []byte(changelog), 0644))
 	}
-
-	logger.Println("creating release...")
-	exitIfError(repo.CreateRelease(changelog, newVer, *isPrerelease, currentBranch, currentSha))
 
 	if *ghr {
 		exitIfError(ioutil.WriteFile(".ghr", []byte(fmt.Sprintf("-u %s -r %s v%s", repo.Owner, repo.Repo, newVer.String())), 0644))
@@ -154,6 +147,13 @@ func main() {
 	if *updateFile != "" {
 		exitIfError(update.Apply(*updateFile, newVer.String()))
 	}
+
+	if *dry {
+		exitIfError(errors.New("DRY RUN: no release was created"))
+	}
+
+	logger.Println("creating release...")
+	exitIfError(repo.CreateRelease(changelog, newVer, *isPrerelease, currentBranch, currentSha))
 
 	logger.Println("done.")
 }

--- a/pkg/semrel/semrel.go
+++ b/pkg/semrel/semrel.go
@@ -101,7 +101,7 @@ func parseCommit(commit *github.RepositoryCommit) *Commit {
 	c.Change = Change{
 		Major: breakingPattern.MatchString(commit.Commit.GetMessage()),
 		Minor: c.Type == "feat",
-		Patch: c.Type == "fix",
+		Patch: true,
 	}
 	return c
 }


### PR DESCRIPTION
### What did I change?

- Moved releasing all the way to the end of `main`
- Moved the dry run check just before releasing

### How did I test this?

- Built it locally and ran the command to generate changelog and version files with dry run

### Why I'm suggesting this change?

The use case I have for making this change is the following:
- I need the version number as part of my build (I'm using Gradle to generate the JAR package)
- I want the build to fail if tests, building the Docker image or package fail
  - No release should be generated when that happens
- At the end, if everything goes well, run the same command again with no `--dry` so that the release actually gets created