### PR TITLE
Use different exit code if no release was created

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Christoph Witzko
+Copyright (c) 2020 Christoph Witzko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ If you commit to this branch a new incremental pre-release is created everytime 
 
 The [MIT License (MIT)](http://opensource.org/licenses/MIT)
 
-Copyright © 2017 [Christoph Witzko](https://twitter.com/christophwitzko)
+Copyright © 2020 [Christoph Witzko](https://twitter.com/christophwitzko)

--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -17,10 +17,14 @@ import (
 
 var SRVERSION string
 
-func errorHandler(logger *log.Logger) func(error) {
-	return func(err error) {
+func errorHandler(logger *log.Logger) func(error, ...int) {
+	return func(err error, exitCode ...int) {
 		if err != nil {
 			logger.Println(err)
+			if len(exitCode) == 1 {
+				os.Exit(exitCode[0])
+				return
+			}
 			os.Exit(1)
 		}
 	}
@@ -135,12 +139,12 @@ func main() {
 	logger.Println("calculating new version...")
 	newVer := semrel.GetNewVersion(commits, release)
 	if newVer == nil {
-		exitIfError(errors.New("no change"))
+		exitIfError(errors.New("no change"), 65)
 	}
 	logger.Println("new version: " + newVer.String())
 
 	if *dry {
-		exitIfError(errors.New("DRY RUN: no release was created"))
+		exitIfError(errors.New("DRY RUN: no release was created"), 65)
 	}
 
 	logger.Println("generating changelog...")


### PR DESCRIPTION
This closes #8