### PR TITLE
feat: tag matching

### DIFF
--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
 	"github.com/go-semantic-release/semantic-release/pkg/condition"
 	"github.com/go-semantic-release/semantic-release/pkg/config"
 	"github.com/go-semantic-release/semantic-release/pkg/semrel"
 	"github.com/go-semantic-release/semantic-release/pkg/update"
 	"github.com/urfave/cli/v2"
-	"io/ioutil"
-	"log"
-	"os"
-	"strings"
 )
 
 // SRVERSION is the semantic-release version (added at compile time)
@@ -95,7 +97,13 @@ func cliHandler(c *cli.Context) error {
 	}
 
 	logger.Println("getting latest release...")
-	release, err := repo.GetLatestRelease(conf.BetaRelease.MaintainedVersion)
+	var matchRegex *regexp.Regexp
+	match := strings.TrimSpace(conf.Match)
+	if match != "" {
+		logger.Printf("getting latest release matching %s...", match)
+		matchRegex = regexp.MustCompile("^" + match)
+	}
+	release, err := repo.GetLatestRelease(conf.BetaRelease.MaintainedVersion, matchRegex)
 	exitIfError(err)
 	logger.Println("found version: " + release.Version.String())
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/urfave/cli/v2"
 	"os"
+
+	"github.com/urfave/cli/v2"
 )
 
 type (
@@ -21,6 +22,7 @@ type (
 		Prerelease  bool
 		TravisCom   bool
 		BetaRelease BetaRelease
+		Match       string
 	}
 
 	BetaRelease struct {
@@ -42,6 +44,7 @@ func NewConfig(c *cli.Context) *Config {
 		GheHost:    c.String("ghe-host"),
 		Prerelease: c.Bool("prerelease"),
 		TravisCom:  c.Bool("travis-com"),
+		Match:      c.String("match"),
 	}
 
 	f, err := os.OpenFile(".semrelrc", os.O_RDONLY, 0)

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -55,4 +55,8 @@ var CliFlags = []cli.Flag{
 		Name:  "travis-com",
 		Usage: "force semantic-release to use the travis-ci.com API endpoint",
 	},
+	&cli.StringFlag{
+		Name:  "match",
+		Usage: "Only consider tags matching the given glob(7) pattern, excluding the \"refs/tags/\" prefix.",
+	},
 }

--- a/pkg/semrel/semrel.go
+++ b/pkg/semrel/semrel.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/google/go-github/v30/github"
-	"golang.org/x/oauth2"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/google/go-github/v30/github"
+	"golang.org/x/oauth2"
 )
 
 var commitPattern = regexp.MustCompile("^(\\w*)(?:\\((.*)\\))?\\: (.*)$")
@@ -122,7 +123,7 @@ func (repo *Repository) GetCommits(sha string) ([]*Commit, error) {
 	return ret, nil
 }
 
-func (repo *Repository) GetLatestRelease(vrange string) (*Release, error) {
+func (repo *Repository) GetLatestRelease(vrange string, re *regexp.Regexp) (*Release, error) {
 	allReleases := make(Releases, 0)
 	opts := &github.ReferenceListOptions{"tags", github.ListOptions{PerPage: 100}}
 	for {
@@ -134,7 +135,11 @@ func (repo *Repository) GetLatestRelease(vrange string) (*Release, error) {
 			return nil, err
 		}
 		for _, r := range refs {
-			version, err := semver.NewVersion(strings.TrimPrefix(r.GetRef(), "refs/tags/"))
+			tag := strings.TrimPrefix(r.GetRef(), "refs/tags/")
+			if re != nil && !re.MatchString(tag) {
+				continue
+			}
+			version, err := semver.NewVersion(tag)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
add option to match tags similar to `git describe`

We use semantic-release for versioning our commits and it works fine as long as all tags follow the vx.x.x pattern produce by the app. However, when a tag is created manually in the repo e.g. `2020.04.18` semantic-release bases the next tag on this new tag.  

This conflicts with what go modules expects so we would like to be able to match which tags to be considered when calculating the next tag similar to how `git describe` allows you to e.g

```
git describe --match "v[0-9]*" --abbrev=0 --tags
```

Without the match option you get

```
$ semantic-release -dry
[semantic-release]: detected CI: none
[semantic-release]: getting default branch...
[semantic-release]: found default branch: master
[semantic-release]: found current branch: master
[semantic-release]: found current sha: master
[semantic-release]: running CI condition...
[semantic-release]: getting latest release...
[semantic-release]: found version: 2020.4.22
[semantic-release]: getting commits...
[semantic-release]: calculating new version...
[semantic-release]: new version: 2020.5.0
[semantic-release]: DRY RUN: no release was created
```

With the match option you get

```
$ semantic-release -dry  --match "v[0-9]*"
[semantic-release]: detected CI: none
[semantic-release]: getting default branch...
[semantic-release]: found default branch: master
[semantic-release]: found current branch: master
[semantic-release]: found current sha: master
[semantic-release]: running CI condition...
[semantic-release]: getting latest release...
[semantic-release]: found match v[0-9]* ...
[semantic-release]: found version: 1.5.0
[semantic-release]: getting commits...
[semantic-release]: calculating new version...
[semantic-release]: new version: 1.6.0
[semantic-release]: DRY RUN: no release was created
```

Hopefully, others find this useful and you would consider including.