### PR TITLE
chore: Added go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![CI](https://github.com/go-semantic-release/semantic-release/workflows/CI/badge.svg?branch=master)](https://github.com/go-semantic-release/semantic-release/actions?query=workflow%3ACI+branch%3Amaster)
 [![Build Status](https://travis-ci.org/go-semantic-release/semantic-release.svg?branch=master)](https://travis-ci.org/go-semantic-release/semantic-release)
 [![pipeline status](https://gitlab.com/go-semantic-release/semantic-release/badges/master/pipeline.svg)](https://gitlab.com/go-semantic-release/semantic-release/pipelines)
+[![Go Report Card](https://goreportcard.com/badge/github.com/go-semantic-release/semantic-release)](https://goreportcard.com/report/github.com/go-semantic-release/semantic-release)
 
 > fully automated package/module/image publishing
 


### PR DESCRIPTION
Added go report card: https://github.com/go-semantic-release/semantic-release/tree/chore/added-reportcard

The only lint issue is missing export comments
```
**Line 9: warning: exported type GitHubActions should have comment or be unexported (golint)**
```

https://goreportcard.com/report/github.com/go-semantic-release/semantic-release

also a project that has *all* the badges
https://github.com/030/go-yq