### PR TITLE
feat: add config to enable prettified changelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ Plugins can be configured using CLI flags or the `.semrelrc` config file. By usi
       "name": "default"
     },
     "changelog-generator": {
-      "name": "default"
+      "name": "default",
+      "options": {
+        "prettified_output": "true"
+      }
     },
     "provider": {
       "name": "gitlab",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Plugins can be configured using CLI flags or the `.semrelrc` config file. By usi
     "changelog-generator": {
       "name": "default",
       "options": {
-        "prettified_output": "true"
+        "emojis": "true"
       }
     },
     "provider": {

--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -218,8 +218,8 @@ func cliHandler(cmd *cobra.Command, args []string) {
 	logger.Printf("changelog-generator plugin: %s@%s\n", changelogGenerator.Name(), changelogGenerator.Version())
 	exitIfError(changelogGenerator.Init(conf.ChangelogGeneratorOpts))
 
-	if conf.ChangelogGeneratorOpts["prettified_output"] == "true" {
-		logger.Printf("changelog-generator prettified_output: %s\n", conf.ChangelogGeneratorOpts["prettified_output"])
+	if conf.ChangelogGeneratorOpts["emojis"] == "true" {
+		logger.Printf("changelog-generator emojis: %s\n", conf.ChangelogGeneratorOpts["emojis"])
 	}
 
 	changelogRes := changelogGenerator.Generate(&generator.ChangelogGeneratorConfig{

--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -218,6 +218,10 @@ func cliHandler(cmd *cobra.Command, args []string) {
 	logger.Printf("changelog-generator plugin: %s@%s\n", changelogGenerator.Name(), changelogGenerator.Version())
 	exitIfError(changelogGenerator.Init(conf.ChangelogGeneratorOpts))
 
+	if conf.ChangelogGeneratorOpts["prettified_output"] == "true" {
+		logger.Printf("changelog-generator prettified_output: %s\n", conf.ChangelogGeneratorOpts["prettified_output"])
+	}
+
 	changelogRes := changelogGenerator.Generate(&generator.ChangelogGeneratorConfig{
 		Commits:       commits,
 		LatestRelease: release,

--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -218,10 +218,6 @@ func cliHandler(cmd *cobra.Command, args []string) {
 	logger.Printf("changelog-generator plugin: %s@%s\n", changelogGenerator.Name(), changelogGenerator.Version())
 	exitIfError(changelogGenerator.Init(conf.ChangelogGeneratorOpts))
 
-	if conf.ChangelogGeneratorOpts["emojis"] == "true" {
-		logger.Printf("changelog-generator emojis: %s\n", conf.ChangelogGeneratorOpts["emojis"])
-	}
-
 	changelogRes := changelogGenerator.Generate(&generator.ChangelogGeneratorConfig{
 		Commits:       commits,
 		LatestRelease: release,


### PR DESCRIPTION
Hi @christophwitzko ,

As already discussed in [#3 (changelog-generator)](https://github.com/go-semantic-release/changelog-generator-default/issues/3)  here is the second of the two PRs regarding the prettified changelogs.

It will simple work with the `changelog-generator-opt` config which can be provided when running semantic-release. If you dont provide the config it wont prettify the changelogs of course.

Within this repo their is actually no change needed from a code perspective. I simply added a small `print` statement to indicate the config to the user.

Here is an example call including the final `CHANGELOG.md`:

```
./semantic-release --provider "gitlab" --token $TOKEN --provider-opt "gitlab_projectid=42" --no-ci --dry --changelog "CHANGELOG.md" --changelog-generator-opt "emojis=true"
[go-semantic-release]: version:
[go-semantic-release]: ci-condition plugin: default@1.2.2
[go-semantic-release]: provider plugin: GitLab@1.4.1
[go-semantic-release]: getting default branch...
[go-semantic-release]: found default branch: master
[go-semantic-release]: found current branch: master
[go-semantic-release]: found current sha: master
[go-semantic-release]: getting latest release...
[go-semantic-release]: found version: 1.1.2
[go-semantic-release]: getting commits...
[go-semantic-release]: analyzing commits...
[go-semantic-release]: commit-analyzer plugin: default@1.3.1
[go-semantic-release]: calculating new version...
[go-semantic-release]: new version: 1.1.3
[go-semantic-release]: generating changelog...
[go-semantic-release]: changelog-generator plugin: default@dev
[go-semantic-release]: changelog-generator prettified_output: true
[go-semantic-release]: DRY RUN: no release was created
```

```
cat CHANGELOG.md

## 1.1.3 (2020-12-08)

#### 🐞 Bug Fixes

* resolve refresh bug (a994ee5c)
```

Feel free to review, I am happy for feedback.

Regards
Timo