### PR TITLE
chore: Add OCI container labels on release builds

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -17,7 +17,7 @@ export IMAGE_NAME_VERSION="$IMAGE_NAME:$VERSION"
 export GL_IMAGE_NAME="registry.gitlab.com/go-semantic-release/semantic-release"
 export GL_IMAGE_NAME_VERSION="$GL_IMAGE_NAME:$VERSION"
 
-docker build --build-arg VERSION=$VERSION -t $IMAGE_NAME_VERSION .
+docker build --build-arg VERSION=$VERSION --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" --label "org.opencontainers.image.version=$VERSION" --label "org.opencontainers.image.revision=$GITHUB_SHA" --label "org.opencontainers.image.created=$(date --rfc-3339 ns)" --label "org.opencontainers.image.title=semantic-release" --label "org.opencontainers.image.documentation=MIT" -t $IMAGE_NAME_VERSION .
 docker tag $IMAGE_NAME_VERSION $IMAGE_NAME
 docker tag $IMAGE_NAME_VERSION $GL_IMAGE_NAME
 docker tag $IMAGE_NAME_VERSION $GL_IMAGE_NAME_VERSION


### PR DESCRIPTION
This patch introduces the OCI labels to release builds. It utilises
GitHub's variables to fill in dynamic parts. One could also use GitLab
variables to do this, if wanted. The overall idea is to improve the
integration of the image with tools like renovate, which discover such
labels on images and automatically link to changelogs and alike.

References:
https://github.com/opencontainers/image-spec/blob/67d2d5658fe0476ab9bf414cec164077ebff3920/annotations.md
https://docs.github.com/en/actions/learn-github-actions/environment-variables
https://github.com/renovatebot/renovate/blob/70c030740540c69b599036c9b93e180c904614e6/lib/datasource/docker/index.ts#L266-L269