### PR TITLE
fix: Use the correct OCI container label for license

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -17,7 +17,7 @@ export IMAGE_NAME_VERSION="$IMAGE_NAME:$VERSION"
 export GL_IMAGE_NAME="registry.gitlab.com/go-semantic-release/semantic-release"
 export GL_IMAGE_NAME_VERSION="$GL_IMAGE_NAME:$VERSION"
 
-docker build --build-arg VERSION=$VERSION --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" --label "org.opencontainers.image.version=$VERSION" --label "org.opencontainers.image.revision=$GITHUB_SHA" --label "org.opencontainers.image.created=$(date --rfc-3339 ns)" --label "org.opencontainers.image.title=semantic-release" --label "org.opencontainers.image.documentation=MIT" -t $IMAGE_NAME_VERSION .
+docker build --build-arg VERSION=$VERSION --label "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" --label "org.opencontainers.image.version=$VERSION" --label "org.opencontainers.image.revision=$GITHUB_SHA" --label "org.opencontainers.image.created=$(date --rfc-3339 ns)" --label "org.opencontainers.image.title=semantic-release" --label "org.opencontainers.image.license=MIT" -t $IMAGE_NAME_VERSION .
 docker tag $IMAGE_NAME_VERSION $IMAGE_NAME
 docker tag $IMAGE_NAME_VERSION $GL_IMAGE_NAME
 docker tag $IMAGE_NAME_VERSION $GL_IMAGE_NAME_VERSION


### PR DESCRIPTION
This patch fixes the copy-paste mistake from the last commit, and
adjusts the wrongly used `org.opencontainers.image.documentation` label,
which should link to documentation, not state "MIT" with the correct
`org.opencontainers.image.license` label which handles licenses.

Shoutout to @ErikMichelson for spotting it.

References:
https://github.com/opencontainers/image-spec/blob/67d2d5658fe0476ab9bf414cec164077ebff3920/annotations.md