### PR TITLE
doc: update the GitLab CI/CD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,16 @@ You can set the GitLab token via the `GITLAB_TOKEN` environment variable or the 
   - release
 
 release:
-  image: registry.gitlab.com/go-semantic-release/semantic-release:latest # Replace this with the current release
+  image:
+    name: registry.gitlab.com/go-semantic-release/semantic-release:latest # Replace this with the current release
+    entrypoint: [""]
   stage: release
   # Remove this if you want a release created for each push to master
   when: manual
   only:
     - master
   script:
-    - release
+    - semantic-release release # Add --allow-no-changes if you want to create a release for each push
 ```
 
 


### PR DESCRIPTION
Without overwriting the `entrypoint` the job just silently does nothing which may lead to some frustration for the user.

Signed-off-by: Christian Ege <ch@ege.io>