### PR TITLE
Feature: add pre-release hook

### DIFF
--- a/cmd/semantic-release/main.go
+++ b/cmd/semantic-release/main.go
@@ -284,6 +284,20 @@ func cliHandler(cmd *cobra.Command, _ []string) {
 		exitIfError(errors.New("DRY RUN: no release was created"), 0)
 	}
 
+	herr := hooksExecutor.PreRelease(&hooks.SuccessHookConfig{
+		Commits:     commits,
+		PrevRelease: release,
+		NewRelease: &semrel.Release{
+			SHA:     currentSha,
+			Version: newVer,
+		},
+		Changelog: changelogRes,
+		RepoInfo:  repoInfo,
+	})
+	if herr != nil {
+		logger.Printf("there was an error executing the hooks plugins: %s", herr.Error())
+	}
+
 	logger.Println("creating release...")
 	newRelease := &provider.CreateReleaseConfig{
 		Changelog:  changelogRes,
@@ -318,7 +332,7 @@ func cliHandler(cmd *cobra.Command, _ []string) {
 		}
 	}
 
-	herr := hooksExecutor.Success(&hooks.SuccessHookConfig{
+	herr = hooksExecutor.Success(&hooks.SuccessHookConfig{
 		Commits:     commits,
 		PrevRelease: release,
 		NewRelease: &semrel.Release{

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -8,6 +8,7 @@ type Hooks interface {
 	Version() string
 	Success(*SuccessHookConfig) error
 	NoRelease(*NoReleaseConfig) error
+	PreRelease(*SuccessHookConfig) error
 }
 
 type ChainedHooksExecutor struct {
@@ -29,6 +30,17 @@ func (c *ChainedHooksExecutor) NoRelease(config *NoReleaseConfig) error {
 	for _, h := range c.HooksChain {
 		name := h.Name()
 		err := h.NoRelease(config)
+		if err != nil {
+			return fmt.Errorf("%s hook has failed: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func (c *ChainedHooksExecutor) PreRelease(config *SuccessHookConfig) error {
+	for _, h := range c.HooksChain {
+		name := h.Name()
+		err := h.PreRelease(config)
 		if err != nil {
 			return fmt.Errorf("%s hook has failed: %w", name, err)
 		}

--- a/pkg/hooks/hooks.proto
+++ b/pkg/hooks/hooks.proto
@@ -63,8 +63,6 @@ message NoReleaseHook {
   }
 }
 
-
-
 service HooksPlugin {
   rpc Init(HooksInit.Request) returns (HooksInit.Response);
   rpc Name(HooksName.Request) returns (HooksName.Response);

--- a/pkg/hooks/hooks.proto
+++ b/pkg/hooks/hooks.proto
@@ -63,10 +63,13 @@ message NoReleaseHook {
   }
 }
 
+
+
 service HooksPlugin {
   rpc Init(HooksInit.Request) returns (HooksInit.Response);
   rpc Name(HooksName.Request) returns (HooksName.Response);
   rpc Version(HooksVersion.Request) returns (HooksVersion.Response);
   rpc Success(SuccessHook.Request) returns (SuccessHook.Response);
   rpc NoRelease(NoReleaseHook.Request) returns (NoReleaseHook.Response);
+  rpc PreRelease(SuccessHook.Request) returns (SuccessHook.Response);
 }

--- a/pkg/hooks/hooks_wrapper.go
+++ b/pkg/hooks/hooks_wrapper.go
@@ -47,6 +47,15 @@ func (h *Server) NoRelease(_ context.Context, request *NoReleaseHook_Request) (*
 	return res, nil
 }
 
+func (h *Server) PreRelease(_ context.Context, request *SuccessHook_Request) (*SuccessHook_Response, error) {
+	err := h.Impl.PreRelease(request.Config)
+	res := &SuccessHook_Response{}
+	if err != nil {
+		res.Error = err.Error()
+	}
+	return res, nil
+}
+
 type Client struct {
 	Impl HooksPluginClient
 }
@@ -95,6 +104,19 @@ func (h *Client) Success(config *SuccessHookConfig) error {
 
 func (h *Client) NoRelease(config *NoReleaseConfig) error {
 	res, err := h.Impl.NoRelease(context.Background(), &NoReleaseHook_Request{
+		Config: config,
+	})
+	if err != nil {
+		return err
+	}
+	if res.Error != "" {
+		return errors.New(res.Error)
+	}
+	return nil
+}
+
+func (h *Client) PreRelease(config *SuccessHookConfig) error {
+	res, err := h.Impl.PreRelease(context.Background(), &SuccessHook_Request{
 		Config: config,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR adds a hook just prior to creating a release.

My use-case for this is a desire to trigger a build of a code-base, units tests and other tests before release. This allows one to do minimal amount of work after the release has been created, and thus also allows one to not have to deal with rolling back a release should that code fail for whatever reason.

If this PR is approved, I intend to add support for this hook to the `exec` plugin as well.

**Notes:**

1. I'm not sure on the naming of the hook. `PreRelease` does describe what the hook does, but it also might be confusing as it clashes with the prerelease concept from SemVer. Let me know if another name should be used.
2. I didn't include changes from running the `scripts/generate.sh` script because I couldn't find the similar versions of protoc, protoc-gen-go and protoc-gen-go-grpc easily. I tried with the latest versions and the code seems to compile fine, but there's a lot of changes introduced. Let me know if there's some other way you usually run the script, if I should generate using latest versions or if I should spend time sourcing the right versions.